### PR TITLE
Updated interview request form, listings site, and details site

### DIFF
--- a/mock-interview-app/src/main/webapp/InterviewRequestDetails.html
+++ b/mock-interview-app/src/main/webapp/InterviewRequestDetails.html
@@ -11,12 +11,19 @@
     <link rel="stylesheet" href="style.css">
     <script src="script.js"></script>
   </head>
-  <body onload="getSections();getInterviewRequests(&quot;None&quot;);">
+  <body onload="getSections();getInterviewDetails();">
     <div id="header-placeholder"></div>
     <div class="container" id="content">
         <h1>Interview Request Details</h1>
-        
-        <div id="interview-listings">
+        <div class="details">
+          <p><b>Name:</b> <span id="listing-name"></span></p>
+          <p><b>Spoken Language:</b> <span id="listing-spoken"></span></p>
+          <p><b>Programming Language:</b> <span id="listing-programming"></span></p>
+          <p><b>Preferred Topic (If Any):</b> <span id="listing-topic"></span></p>
+          <p id="listing-intro"></p>
+          <p><b>Times Available: </b></p>
+          <div id="times-available"></div>
+          <a class="btn btn-primary btn-sm" href="#">Interview This Person</a>
         </div>
     </div>
     <div id="footer-placeholder"></div>

--- a/mock-interview-app/src/main/webapp/InterviewRequestForm.html
+++ b/mock-interview-app/src/main/webapp/InterviewRequestForm.html
@@ -13,7 +13,13 @@
   <body onload="getSections();getAlert();">
         <div id="header-placeholder"></div>
         <div id="content">
+            <h3>Request an interview here!</h3>
+            <br>
             <form action="/data" method="POST">
+                <label for="name">Enter your name:</label>
+                <input type="text" name="name"/> <br><br>
+                <label for="intro">Give us a very brief introduction of who you are for people to see:</label>
+                <textarea name="intro" rows="8" cols="70"></textarea> <br><br>
                 <label for="interview_topic">Enter the topic you would like to interview on:</label>
                 <input type="text" list="interview_topic" name="topic"/>
                 <datalist id="interview_topic">
@@ -46,7 +52,7 @@
                 <label for="environment_link">Paste a link to a pair programming environment for your interview:</label>
                 <input type="text" id="environment_link" name="environmentURL"/> <br/><br/>
 
-                <label for="time_availability">Choose your time availability to interview:</label> </br></br>
+                <label for="time_availability">Choose your time availability to interview:</label>
                 <div id="dynamicInput">
                     Entry 1</br><input type="datetime-local" id="time_availability" name="time_availability" min="2020-01-01T00:00" max="2020-12-31T00:00">
                 </div>

--- a/mock-interview-app/src/main/webapp/script.js
+++ b/mock-interview-app/src/main/webapp/script.js
@@ -13,37 +13,46 @@
 // limitations under the License.
 
 async function getInterviewRequests(language) {
-    const queryString = window.location.search;
-    const urlParams = new URLSearchParams(queryString);
-    const key = urlParams.get('key');
-    let response;
-    if(key != null) {
-        response = await fetch('/data?key=' + key);
-    }
-    else {
-        response = await fetch('/data');
-    }
+    const response = await fetch('/data');
     const listings = await response.json();
     let html = "";
     for(const listing of listings) {
         if(language != "None" && listing.programmingLanguage != language)
             continue;
         html += `<div class="listing">`;
-        html += `<p><b>Preferred Topic (If Any):</b> ${listing.topic}</p>`;
-        html += `<p><b>Preferred Spoken Language:</b> ${listing.spokenLanguage}</p>`;
+        html += `<p><b>Name:</b> ${listing.name}</p>`;
+        html += `<p><b>Spoken Language:</b> ${listing.spokenLanguage}</p>`;
         html += `<p><b>Programming Language:</b> ${listing.programmingLanguage}</p>`;
-        html += `<p><b>Hangouts meeting:</b> ${listing.communicationURL}</p>`;
-        html += `<p><b>Programming environment:</b> ${listing.environmentURL}</p>`;
-        let timesAvailable = "";
-        for(const time of listing.timesAvailable) {
-            timesAvailable += time + " ";
-        }
-        html += `<p><b>Time Availability:</b> ${timesAvailable}</p>`;
-
-        html += `<a href="InterviewRequestDetails.html?key=${listing.key}">Read More</a>`;
+        html += `<p><b>Preferred Topic (If Any):</b> ${listing.topic}</p>`;
+        html += `<a class="btn btn-primary btn-sm" href="InterviewRequestDetails.html?key=${listing.key}">Read More</a>`;
         html += `</div>`;
     }
     document.getElementById('interview-listings').innerHTML = html;
+}
+
+async function getInterviewDetails() {
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    const key = urlParams.get('key');
+    if (key == null) {
+      alert('Error: No key specified.');
+      return;
+    }
+    const response = await fetch('/data?key=' + key);
+    const listing = await response.json();
+    console.log(listing);
+    $("#listing-name").text(listing.name);
+    $("#listing-spoken").text(listing.spokenLanguage);
+    $("#listing-programming").text(listing.programmingLanguage);
+    $("#listing-topic").text(listing.topic);
+    $("#listing-intro").text(listing.intro);
+
+    let timesAvailable = "";
+    for (const time of listing.timesAvailable)
+      timesAvailable += `<p>${time}</p>`;
+
+    $("#times-available").html(timesAvailable);
+
 }
 
 async function login() {

--- a/mock-interview-app/src/main/webapp/style.css
+++ b/mock-interview-app/src/main/webapp/style.css
@@ -34,12 +34,24 @@ body {
 }
 
 .listing {
+    transition: box-shadow .3s;
     border-radius: 15px;
-    background: #DDDDDD;
+    background: #D3D3D3;
     padding: 15px; 
     margin-bottom: 20px;
 }
 
 .listing p {
     font-size: 16px;
+}
+
+.listing:hover {
+	box-shadow: 0 0 12px rgba(0,0,0,0.3); 
+}
+
+.details {
+	border-radius: 15px;
+    background: #D3D3D3;
+    padding: 15px; 
+    margin-bottom: 20px;
 }


### PR DESCRIPTION
Added two new fields to the interview request form: Name and Intro.
We have no current way to get the user's name or some type of username, because currently you can only login with your email.
To add a little bit of diversity to each listing I added an intro field where users can briefly talk about themselves.

The site with all the listings has been updated to show less information, the details site has been updated to show all relevant information.

The backend was updated to return only one listing instead of an array with only one element when retrieving the information for a single listing.